### PR TITLE
Empty Vaults are equal

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/vault/Key.scala
+++ b/core/src/main/scala/io/chrisdavenport/vault/Key.scala
@@ -9,11 +9,11 @@ import io.chrisdavenport.unique.Unique
   * Since it can only be created as a result of that, it links
   * a Unique identifier to a type known by the compiler.
   */
-final class Key[A] private (private[vault] val unique: Unique)
+sealed abstract case class Key[A] private (private[vault] val unique: Unique)
 
 object Key {
   /**
    * Create A Typed Key
    */
-  def newKey[F[_]: Sync, A]: F[Key[A]] = Unique.newUnique[F].map(new Key[A](_))
+  def newKey[F[_]: Sync, A]: F[Key[A]] = Unique.newUnique[F].map(new Key[A](_){})
 }

--- a/core/src/main/scala/io/chrisdavenport/vault/Locker.scala
+++ b/core/src/main/scala/io/chrisdavenport/vault/Locker.scala
@@ -12,7 +12,7 @@ import io.chrisdavenport.unique.Unique
  * know that the type MUST be the type of the Key, so we can
  * bring it back as that type safely.
  **/
-final class Locker private(private val unique: Unique, private val a: Any){
+sealed abstract case class Locker private(private val unique: Unique, private val a: Any){
   /**
    * Retrieve the value from the Locker. If the reference equality
    * instance backed by a `Unique` value is the same then allows
@@ -29,7 +29,7 @@ object Locker {
   /**
    * Put a single value into a Locker
    */
-  def lock[A](k: Key[A], a: A): Locker = new Locker(k.unique, a.asInstanceOf[Any])
+  def lock[A](k: Key[A], a: A): Locker = new Locker(k.unique, a.asInstanceOf[Any]) {}
 
   /**
    * Retrieve the value from the Locker. If the reference equality

--- a/core/src/main/scala/io/chrisdavenport/vault/Vault.scala
+++ b/core/src/main/scala/io/chrisdavenport/vault/Vault.scala
@@ -9,7 +9,7 @@ import io.chrisdavenport.unique.Unique
  * has no type information, all the type information is contained 
  * in the keys.
  */
-final class Vault private (private val m: Map[Unique, Locker]) {
+sealed abstract case class Vault private (private val m: Map[Unique, Locker]) {
   /**
     * Empty this Vault
     */
@@ -36,10 +36,14 @@ final class Vault private (private val m: Map[Unique, Locker]) {
   def ++(that: Vault): Vault = Vault.union(this, that)
 }
 object Vault {
+
+  private def newVault(m: Map[Unique, Locker]): Vault =
+    new Vault(m) {}
+
   /**
    * The Empty Vault 
    */
-  def empty = new Vault(Map.empty)
+  def empty = newVault(Map.empty)
 
   /**
    * Lookup the value of a key in the vault
@@ -51,13 +55,13 @@ object Vault {
    * Insert a value for a given key. Overwrites any previous value.
    */
   def insert[A](k: Key[A], a: A, v: Vault): Vault = 
-    new Vault(v.m + (k.unique -> Locker.lock(k, a)))
+    newVault(v.m + (k.unique -> Locker.lock(k, a)))
   
   /**
    * Delete a key from the vault
    */
   def delete[A](k: Key[A], v: Vault): Vault = 
-    new Vault(v.m - k.unique)
+    newVault(v.m - k.unique)
   
   /**
    * Adjust the value for a given key if it's present in the vault.
@@ -69,6 +73,6 @@ object Vault {
    * Merge Two Vaults. v2 is prioritized.
    */
   def union(v1: Vault, v2: Vault): Vault = 
-    new Vault(v1.m ++ v2.m)
+    newVault(v1.m ++ v2.m)
 
 }

--- a/core/src/test/scala/io/chrisdavenport/vault/VaultSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/vault/VaultSpec.scala
@@ -44,6 +44,18 @@ class VaultSpec extends Specification with ScalaCheck {
 
       emptyVault1 must_=== emptyVault2
     }
+    "be equal to an another Vault, if they contain the same elements" >> {
+      val key = Key.newKey[IO, Int].unsafeRunSync
+      val v1 = Vault.empty.insert(key, 1)
+      val v2 = Vault.empty.insert(key, 1)
+      v1 must_=== v2
+    }
+    "not be equal to an another Vault, if they contain different value under the same key" >> {
+      val key = Key.newKey[IO, Int].unsafeRunSync
+      val v1 = Vault.empty.insert(key, 1)
+      val v2 = Vault.empty.insert(key, 2)
+      v1 must_!== v2
+    }
   }
 
 }

--- a/core/src/test/scala/io/chrisdavenport/vault/VaultSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/vault/VaultSpec.scala
@@ -38,6 +38,12 @@ class VaultSpec extends Specification with ScalaCheck {
       } yield Vault.empty.insert(key1, i).lookup(key2)
       test.unsafeRunSync must_=== None
     }
+    "be equal to an empty Vault, if it is empty too" >> {
+      val emptyVault1: Vault = Vault.empty
+      val emptyVault2: Vault = Vault.empty
+
+      emptyVault1 must_=== emptyVault2
+    }
   }
 
 }


### PR DESCRIPTION
empty `Vault`s should be equal
so I made `Vault` a case class, so that I don't have to implement `equals` myself
/cc @jendakol @hanny24
