### PR TITLE
Bump to scalajs-1.4.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.9.7")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.19.3")


### PR DESCRIPTION
I think this may fix the empty jars that @m-sp reported.

On scalajs-1.3.0, we get a series of:

```
[warn] Attempting to overwrite /home/ross/src/vault/target/sonatype-staging/2.1.0-M14-ross/org/typelevel/vault_2.12/2.1.0-M14-ross/vault_2.12-2.1.0-M14-ross-sources.jar (non-SNAPSHOT)
```

They don't happen when publishing just coreJVM or coreJS.  And they don't happen if we upgrade to at least scalajs-1.3.1.  I can't find any mention of it in the release notes, but I'm banking on this warning being related to our false publishing.