### PR TITLE
Adjust links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vault [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/vault_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.chrisdavenport/vault-core_2.12)
+# vault [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.typelevel/vault_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.typelevel/vault_2.12)
 
 Vault is a tiny library that provides a single data structure called vault.
 
@@ -10,11 +10,11 @@ It is analogous to a bank vault, where you can access different bank boxes with 
 
 ## Microsite
 
-Head on over [to the microsite](https://christopherdavenport.github.io/vault/)
+Head on over [to the microsite](https://typelevel.github.io/vault/)
 
 ## Quick Start
 
-To use vault in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use vault in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala


### PR DESCRIPTION
Fixes links to microsite and maven badge which were broken since the move of this repo to typelevel.