### PR TITLE
Rm `sbt-dotty` plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.0")
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.21.0")
 
-// Temporary workaround
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
That plugin is no longer needed because of the SBT version https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html