### PR TITLE
Add a `micrositeUrl` parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tags
 .metals
 .vscode
 .bsp
+.jekyll-cache/

--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,7 @@ lazy val micrositeSettings = {
     micrositeAuthor := "Typelevel",
     micrositeGithubOwner := "typelevel",
     micrositeGithubRepo := "vault",
+    micrositeUrl := "https://typelevel.org",
     micrositeBaseUrl := "/vault",
     micrositeDocumentationUrl := "https://www.javadoc.io/doc/typelevel/vault_2.13",
     micrositeFooterText := None,


### PR DESCRIPTION
According to #231 site is broken currently. I suppose because a `micrositeUrl` parameter wasn't specified. But that needs to check because the site builds well locally.