### PR TITLE
Use `MUnit` in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ val disciplineSpecs2V = "1.1.6"
 val specs2V = "4.10.6"
 val disciplineMunitV = "1.0.9"
 val scalacheckEffectV = "1.0.2"
+val munitCatsEffectV = "1.0.5"
 
 // General Settings
 lazy val commonSettings = Seq(
@@ -109,7 +110,8 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %%% "cats-laws"                  % catsV              % Test,
     "org.typelevel"               %%% "discipline-specs2"          % disciplineSpecs2V  % Test,
     "org.typelevel"               %%% "discipline-munit"           % disciplineMunitV   % Test,
-    "org.typelevel"               %%% "scalacheck-effect-munit"    % scalacheckEffectV  % Test
+    "org.typelevel"               %%% "scalacheck-effect-munit"    % scalacheckEffectV  % Test,
+    "org.typelevel"               %%% "munit-cats-effect-3"        % munitCatsEffectV   % Test
   ),
   // Cursed tags
   mimaPreviousArtifacts ~= (_.filterNot(m => Set("2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.11", "2.1.12").contains(m.revision)))

--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ val catsEffectV = "3.2.2"
 val disciplineSpecs2V = "1.1.6"
 val specs2V = "4.10.6"
 val disciplineMunitV = "1.0.9"
+val scalacheckEffectV = "1.0.2"
 
 // General Settings
 lazy val commonSettings = Seq(
@@ -107,7 +108,8 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %%% "cats-effect"                % catsEffectV,
     "org.typelevel"               %%% "cats-laws"                  % catsV              % Test,
     "org.typelevel"               %%% "discipline-specs2"          % disciplineSpecs2V  % Test,
-    "org.typelevel"               %%% "discipline-munit"           % disciplineMunitV   % Test
+    "org.typelevel"               %%% "discipline-munit"           % disciplineMunitV   % Test,
+    "org.typelevel"               %%% "scalacheck-effect-munit"    % scalacheckEffectV  % Test
   ),
   // Cursed tags
   mimaPreviousArtifacts ~= (_.filterNot(m => Set("2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.11", "2.1.12").contains(m.revision)))

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,7 @@ val catsV = "2.6.1"
 val catsEffectV = "3.2.2"
 val disciplineSpecs2V = "1.1.6"
 val specs2V = "4.10.6"
+val disciplineMunitV = "1.0.9"
 
 // General Settings
 lazy val commonSettings = Seq(
@@ -106,6 +107,7 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %%% "cats-effect"                % catsEffectV,
     "org.typelevel"               %%% "cats-laws"                  % catsV              % Test,
     "org.typelevel"               %%% "discipline-specs2"          % disciplineSpecs2V  % Test,
+    "org.typelevel"               %%% "discipline-munit"           % disciplineMunitV   % Test
   ),
   // Cursed tags
   mimaPreviousArtifacts ~= (_.filterNot(m => Set("2.1.1", "2.1.2", "2.1.3", "2.1.4", "2.1.5", "2.1.6", "2.1.11", "2.1.12").contains(m.revision)))

--- a/build.sbt
+++ b/build.sbt
@@ -95,8 +95,6 @@ lazy val docs = project.in(file("docs"))
 
 val catsV = "2.6.1"
 val catsEffectV = "3.2.2"
-val disciplineSpecs2V = "1.1.6"
-val specs2V = "4.10.6"
 val disciplineMunitV = "1.0.9"
 val scalacheckEffectV = "1.0.2"
 val munitCatsEffectV = "1.0.5"
@@ -108,7 +106,6 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %%% "cats-core"                  % catsV,
     "org.typelevel"               %%% "cats-effect"                % catsEffectV,
     "org.typelevel"               %%% "cats-laws"                  % catsV              % Test,
-    "org.typelevel"               %%% "discipline-specs2"          % disciplineSpecs2V  % Test,
     "org.typelevel"               %%% "discipline-munit"           % disciplineMunitV   % Test,
     "org.typelevel"               %%% "scalacheck-effect-munit"    % scalacheckEffectV  % Test,
     "org.typelevel"               %%% "munit-cats-effect-3"        % munitCatsEffectV   % Test

--- a/core/.jvm/src/test/scala/org/typelevel/vault/VaultSuite.scala
+++ b/core/.jvm/src/test/scala/org/typelevel/vault/VaultSuite.scala
@@ -28,7 +28,7 @@ import org.scalacheck.effect.PropF
 class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   test("Vault should contain a single value correctly") {
     PropF.forAllF {
-      i: Int =>
+      (i: Int) =>
         val emptyVault: Vault = Vault.empty
         val test = Key.newKey[IO, Int].map(k => emptyVault.insert(k, i).lookup(k))
 
@@ -38,7 +38,7 @@ class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("Vault should contain only the last value after inserts") {
     PropF.forAllF {
-      l: List[String] =>
+      (l: List[String]) =>
         val emptyVault: Vault = Vault.empty
         val test = Key.newKey[IO, String].map { k =>
           l.reverse.foldLeft(emptyVault)((v, a) => v.insert(k, a)).lookup(k)
@@ -50,7 +50,7 @@ class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("Vault should contain no value after being emptied") {
     PropF.forAllF {
-      l: List[String] =>
+      (l: List[String]) =>
         val emptyVault : Vault = Vault.empty
         val test : IO[Option[String]] = Key.newKey[IO, String].map{k =>
           l.reverse.foldLeft(emptyVault)((v, a) => v.insert(k, a)).empty.lookup(k)
@@ -62,7 +62,7 @@ class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("Vault should not be accessible via a different key") {
     PropF.forAllF {
-      i: Int =>
+      (i: Int) =>
         val test = for {
           key1 <- Key.newKey[IO, Int]
           key2 <- Key.newKey[IO, Int]

--- a/core/.jvm/src/test/scala/org/typelevel/vault/VaultSuite.scala
+++ b/core/.jvm/src/test/scala/org/typelevel/vault/VaultSuite.scala
@@ -22,48 +22,53 @@
 package org.typelevel.vault
 
 import cats.effect._
-import cats.effect.unsafe.implicits.global
-import org.specs2.mutable.Specification
-import org.specs2.ScalaCheck
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.scalacheck.effect.PropF
 
-class VaultSpec extends Specification with ScalaCheck {
+class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+  test("Vault should contain a single value correctly") {
+    PropF.forAllF {
+      i: Int =>
+        val emptyVault: Vault = Vault.empty
+        val test = Key.newKey[IO, Int].map(k => emptyVault.insert(k, i).lookup(k))
 
-  "Vault" should {
-     "contain a single value correctly" >> prop {
-      (i: Int) =>
-        val emptyVault : Vault = Vault.empty
-
-        Key.newKey[IO, Int].map{k => 
-          emptyVault.insert(k, i).lookup(k)
-        }.unsafeRunSync() === Some(i)
-
+        assertIO(test, Some(i))
     }
-    "contain only the last value after inserts" >> prop {
-      (l: List[String]) =>
-        val emptyVault : Vault = Vault.empty
-        val test : IO[Option[String]] = Key.newKey[IO, String].map{k => 
+  }
+
+  test("Vault should contain only the last value after inserts") {
+    PropF.forAllF {
+      l: List[String] =>
+        val emptyVault: Vault = Vault.empty
+        val test = Key.newKey[IO, String].map { k =>
           l.reverse.foldLeft(emptyVault)((v, a) => v.insert(k, a)).lookup(k)
         }
-        test.unsafeRunSync() === l.headOption
-    }
 
-    "contain no value after being emptied" >> prop {
-      (l: List[String]) =>
+        assertIO(test, l.headOption)
+    }
+  }
+
+  test("Vault should contain no value after being emptied") {
+    PropF.forAllF {
+      l: List[String] =>
         val emptyVault : Vault = Vault.empty
-        val test : IO[Option[String]] = Key.newKey[IO, String].map{k => 
+        val test : IO[Option[String]] = Key.newKey[IO, String].map{k =>
           l.reverse.foldLeft(emptyVault)((v, a) => v.insert(k, a)).empty.lookup(k)
         }
-        test.unsafeRunSync() === None
-    }
 
-    "not be accessible via a different key" >> prop { (i: Int) =>
+        assertIO(test, None)
+    }
+  }
+
+  test("Vault should not be accessible via a different key") {
+    PropF.forAllF {
+      i: Int =>
         val test = for {
           key1 <- Key.newKey[IO, Int]
           key2 <- Key.newKey[IO, Int]
         } yield Vault.empty.insert(key1, i).lookup(key2)
-        test.unsafeRunSync() === None
+
+        assertIO(test, None)
     }
   }
-
-
 }

--- a/core/src/test/scala/org/typelevel/vault/KeySuite.scala
+++ b/core/src/test/scala/org/typelevel/vault/KeySuite.scala
@@ -23,13 +23,10 @@ package org.typelevel.vault
 
 import org.scalacheck._
 import cats.effect.SyncIO
-import org.specs2.mutable.Specification
-import org.typelevel.discipline.specs2.mutable.Discipline
 import cats.kernel.laws.discipline.{EqTests, HashTests}
+import munit.DisciplineSuite
 
-
-class KeyTests extends Specification with Discipline {
-
+class KeySuite extends DisciplineSuite {
   implicit def functionArbitrary[B, A: Arbitrary]: Arbitrary[B => A] = Arbitrary{
     for {
       a <- Arbitrary.arbitrary[A]
@@ -39,7 +36,6 @@ class KeyTests extends Specification with Discipline {
   implicit def uniqueKey[A]: Arbitrary[Key[A]] = Arbitrary{
     Arbitrary.arbitrary[Unit].map(_ => Key.newKey[SyncIO, A].unsafeRunSync())
   }
-
 
   checkAll("Key", HashTests[Key[Int]].hash)
   checkAll("Key", EqTests[Key[Int]].eqv)


### PR DESCRIPTION
A test framework unification for `typelevel` projects and dropping `unsafeRunSync()` is the main goal of this PR.