### PR TITLE
Introduce `InsertKey[-A]` / `LookupKey[+A]` abstraction to allow for variance

### DIFF
--- a/core/src/main/scala/org/typelevel/vault/Key.scala
+++ b/core/src/main/scala/org/typelevel/vault/Key.scala
@@ -31,8 +31,16 @@ import cats.implicits._
  * Since it can only be created as a result of that, it links
  * a Unique identifier to a type known by the compiler.
  */
-final class Key[A] private (private[vault] val unique: Unique.Token) {
+final class Key[A] private (private[vault] val unique: Unique.Token) extends InsertKey[A] with LookupKey[A] {
   override def hashCode(): Int = unique.hashCode()
+}
+
+sealed trait InsertKey[-A] {
+  private[vault] def unique: Unique.Token
+}
+
+sealed trait LookupKey[+A] {
+  private[vault] def unique: Unique.Token
 }
 
 object Key {

--- a/core/src/main/scala/org/typelevel/vault/Locker.scala
+++ b/core/src/main/scala/org/typelevel/vault/Locker.scala
@@ -52,7 +52,27 @@ object Locker {
   /**
    * Put a single value into a Locker
    */
-  def lock[A](k: Key[A], a: A): Locker = new Locker(k.unique, a.asInstanceOf[Any])
+  def lock[A](k: InsertKey[A], a: A): Locker = new Locker(k.unique, a.asInstanceOf[Any])
+
+  /**
+   * Put a single value into a Locker
+   */
+  def lock[A](k: Key[A], a: A): Locker = lock(k: InsertKey[A], a)
+
+  /**
+   * Retrieve the value from the Locker. If the reference equality
+   * instance backed by a `Unique` value is the same then allows
+   * conversion to that type, otherwise as it does not match
+   * then this will be `None`
+   *
+   * @param k The key to check, if the internal Unique value matches
+   * then this Locker can be unlocked as the specifed value
+   * @param l The locked to check against
+   */
+  def unlock[A](k: LookupKey[A], l: Locker): Option[A] =
+    // Equality By Reference Equality
+    if (k.unique === l.unique) Some(l.a.asInstanceOf[A])
+    else None
 
   /**
    * Retrieve the value from the Locker. If the reference equality
@@ -65,7 +85,5 @@ object Locker {
    * @param l The locked to check against
    */
   def unlock[A](k: Key[A], l: Locker): Option[A] =
-    // Equality By Reference Equality
-    if (k.unique === l.unique) Some(l.a.asInstanceOf[A])
-    else None
+    unlock(k: LookupKey[A], l)
 }

--- a/core/src/main/scala/org/typelevel/vault/Locker.scala
+++ b/core/src/main/scala/org/typelevel/vault/Locker.scala
@@ -44,7 +44,18 @@ final class Locker private (private val unique: Unique.Token, private val a: Any
    * @param k The key to check, if the internal Unique value matches
    * then this Locker can be unlocked as the specifed value
    */
-  def unlock[A](k: Key[A]): Option[A] = Locker.unlock(k, this)
+  def unlock[A](k: LookupKey[A]): Option[A] = Locker.unlock(k, this)
+
+  /**
+   * Retrieve the value from the Locker. If the reference equality
+   * instance backed by a `Unique` value is the same then allows
+   * conversion to that type, otherwise as it does not match
+   * then this will be `None`
+   *
+   * @param k The key to check, if the internal Unique value matches
+   * then this Locker can be unlocked as the specifed value
+   */
+  private[vault] def unlock[A](k: Key[A]): Option[A] = unlock(k: LookupKey[A])
 }
 
 object Locker {

--- a/core/src/main/scala/org/typelevel/vault/Vault.scala
+++ b/core/src/main/scala/org/typelevel/vault/Vault.scala
@@ -41,17 +41,37 @@ final class Vault private (private val m: Map[Unique.Token, Locker]) {
   /**
    * Lookup the value of a key in this vault
    */
-  def lookup[A](k: Key[A]): Option[A] = Vault.lookup(k, this)
+  def lookup[A](k: LookupKey[A]): Option[A] = Vault.lookup(k, this)
+
+  /**
+   * Lookup the value of a key in this vault
+   */
+  private[vault] def lookup[A](k: Key[A]): Option[A] = lookup(k: LookupKey[A])
 
   /**
    * Insert a value for a given key. Overwrites any previous value.
    */
-  def insert[A](k: Key[A], a: A): Vault = Vault.insert(k, a, this)
+  def insert[A](k: InsertKey[A], a: A): Vault = Vault.insert(k, a, this)
+
+  /**
+   * Insert a value for a given key. Overwrites any previous value.
+   */
+  private[vault] def insert[A](k: Key[A], a: A): Vault = insert(k: InsertKey[A], a)
 
   /**
    * Checks whether this Vault is empty
    */
   def isEmpty: Boolean = Vault.isEmpty(this)
+
+  /**
+   * Delete a key from the vault
+   */
+  def delete[A](k: InsertKey[A]): Vault = Vault.delete(k, this)
+
+  /**
+   * Delete a key from the vault
+   */
+  def delete[A](k: LookupKey[A]): Vault = Vault.delete(k, this)
 
   /**
    * Delete a key from the vault
@@ -78,20 +98,44 @@ object Vault {
   /**
    * Lookup the value of a key in the vault
    */
-  def lookup[A](k: Key[A], v: Vault): Option[A] =
+  def lookup[A](k: LookupKey[A], v: Vault): Option[A] =
     v.m.get(k.unique).flatMap(Locker.unlock(k, _))
+
+  /**
+   * Lookup the value of a key in the vault
+   */
+  def lookup[A](k: Key[A], v: Vault): Option[A] =
+    lookup(k: LookupKey[A], v)
+
+  /**
+   * Insert a value for a given key. Overwrites any previous value.
+   */
+  def insert[A](k: InsertKey[A], a: A, v: Vault): Vault =
+    new Vault(v.m + (k.unique -> Locker.lock(k, a)))
 
   /**
    * Insert a value for a given key. Overwrites any previous value.
    */
   def insert[A](k: Key[A], a: A, v: Vault): Vault =
-    new Vault(v.m + (k.unique -> Locker.lock(k, a)))
+    insert(k: InsertKey[A], a, v)
 
   /**
    * Checks whether the given Vault is empty
    */
   def isEmpty(v: Vault): Boolean =
     v.m.isEmpty
+
+  /**
+   * Delete a key from the vault
+   */
+  def delete[A](k: InsertKey[A], v: Vault): Vault =
+    new Vault(v.m - k.unique)
+
+  /**
+   * Delete a key from the vault
+   */
+  def delete[A](k: LookupKey[A], v: Vault): Vault =
+    new Vault(v.m - k.unique)
 
   /**
    * Delete a key from the vault


### PR DESCRIPTION
This PR adds to the API traits `InsertKey[-A]` and `LookupKey[+A]` (which `Key[A]` inherits from). The goal is to safely allow variance necessary for passing around keys dynamically (see the following example). This is typesafe and is a source- and binary-compatible change. This style of abstraction is similar to `Ref`/`RefSource`/`RefSink` and `Queue`/`QueueSource`/`QueueSink` in CE3.

```scala
sealed trait Animal { def name: String }
case class Dog(name: String) extends Animal
case class Cat(name: String) extends Animal

def greetings(keys: List[LookupKey[Animal]], vault: Vault) =
  keys.flatMap(k => vault.lookup(k).toList).traverse(a => IO.println(s"hello, ${a.name}"))

for {
  dogKey <- Key.newKey[IO, Dog]
  catKey <- Key.newKey[IO, Cat]
  _ <- greetings(List(dogKey, catKey), Vault.empty)
} yield ()
```

For the record: after a lengthy discussion on Discord @ChristopherDavenport is very 👎 on this change and kindly proposed [this alternative](https://scastie.scala-lang.org/gCLwA2a3RFiqWAdsOOzMkQ) or using shapeless.

Thanks for your consideration!