### PR TITLE
Bump jekyll version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.scala == '2.12.14'
         run: |
           gem install saas
-          gem install jekyll -v 4
+          gem install jekyll -v 4.2.0
 
       - name: Check that workflows are up to date
         run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
@@ -116,7 +116,7 @@ jobs:
       - name: Install microsite dependencies
         run: |
           gem install saas
-          gem install jekyll -v 4
+          gem install jekyll -v 4.2.0
 
       - run: sbt --client '++${{ matrix.scala }}; release'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.scala == '2.12.14'
         run: |
           gem install saas
-          gem install jekyll -v 3.2.1
+          gem install jekyll -v 4
 
       - name: Check that workflows are up to date
         run: sbt --client '++${{ matrix.scala }}; githubWorkflowCheck'
@@ -116,7 +116,7 @@ jobs:
       - name: Install microsite dependencies
         run: |
           gem install saas
-          gem install jekyll -v 3.2.1
+          gem install jekyll -v 4
 
       - run: sbt --client '++${{ matrix.scala }}; release'
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ def rubySetupSteps(cond: Option[String]) = Seq(
                    params = Map("ruby-version" -> "2.6.0"),
                    cond = cond
   ),
-  WorkflowStep.Run(List("gem install saas", "gem install jekyll -v 3.2.1"),
+  WorkflowStep.Run(List("gem install saas", "gem install jekyll -v 4"),
                    name = Some("Install microsite dependencies"),
                    cond = cond
   )

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ def rubySetupSteps(cond: Option[String]) = Seq(
                    params = Map("ruby-version" -> "2.6.0"),
                    cond = cond
   ),
-  WorkflowStep.Run(List("gem install saas", "gem install jekyll -v 4"),
+  WorkflowStep.Run(List("gem install saas", "gem install jekyll -v 4.2.0"),
                    name = Some("Install microsite dependencies"),
                    cond = cond
   )


### PR DESCRIPTION
Towards #231. No idea if this is the fix, but the latest sbt-microsites requires jekyll 4:
https://47degrees.github.io/sbt-microsites/docs/getting-started/