### PR TITLE
Update Scala 2.12 to `2.12.15`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.14, 2.13.6, 3.0.2]
+        scala: [2.12.15, 2.13.6, 3.0.2]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,13 +53,13 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Setup Ruby
-        if: matrix.scala == '2.12.14'
+        if: matrix.scala == '2.12.15'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6.0
 
       - name: Install microsite dependencies
-        if: matrix.scala == '2.12.14'
+        if: matrix.scala == '2.12.15'
         run: |
           gem install saas
           gem install jekyll -v 4.2.0
@@ -69,7 +69,7 @@ jobs:
 
       - run: sbt ++${{ matrix.scala }} headerCheckAll test mimaReportBinaryIssues
 
-      - if: matrix.scala == '2.12.14'
+      - if: matrix.scala == '2.12.15'
         run: sbt ++${{ matrix.scala }} docs/makeMicrosite
 
   publish:
@@ -121,4 +121,4 @@ jobs:
       - run: sbt ++${{ matrix.scala }} release
 
       - name: Publish microsite
-        run: sbt ++${{ matrix.scala }} ++2.12.14 docs/publishMicrosite
+        run: sbt ++${{ matrix.scala }} ++2.12.15 docs/publishMicrosite

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val commonSettings = Seq(
     if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
     else
       Seq(
-        compilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.full)
+        compilerPlugin(("org.typelevel" % "kind-projector" % kindProjectorV).cross(CrossVersion.full))
       )
   ),
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -96,10 +96,18 @@ val catsEffectV = "3.2.8"
 val disciplineMunitV = "1.0.9"
 val scalacheckEffectV = "1.0.2"
 val munitCatsEffectV = "1.0.5"
+val kindProjectorV = "0.13.2"
 
 // General Settings
 lazy val commonSettings = Seq(
   organization := "org.typelevel",
+  libraryDependencies ++= (
+    if (ScalaArtifacts.isScala3(scalaVersion.value)) Nil
+    else
+      Seq(
+        compilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.full)
+      )
+  ),
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "cats-core" % catsV,
     "org.typelevel" %%% "cats-effect" % catsEffectV,

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,11 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-val Scala212 = "2.12.14"
+val Scala212 = "2.12.15"
+val Scala213 = "2.13.6"
+val Scala3 = "3.0.2"
 
 ThisBuild / baseVersion := "3.0"
-ThisBuild / crossScalaVersions := Seq(Scala212, "2.13.6", "3.0.2")
+ThisBuild / crossScalaVersions := Seq(Scala212, Scala213, Scala3)
 ThisBuild / scalaVersion := crossScalaVersions.value.filter(_.startsWith("2.")).last
 ThisBuild / publishFullName := "Christopher Davenport"
 ThisBuild / publishGithubUser := "christopherdavenport"


### PR DESCRIPTION
This updates Scala 2.12 to `2.12.15` and adds a straight dependency on `kind-projector`. Otherwise, it's needed to wait when underlying libs will be released with the recent `kind-projector`.