### PR TITLE
Ignore `scala-js` updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -8,5 +8,6 @@ updates.ignore = [
   { groupId = "org.typelevel", artifactId = "sbt-typelevel-site" },
   { groupId = "org.typelevel", artifactId = "cats-core" },
   { groupId = "org.scala-sbt" },
-  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" },
+  { groupId = "org.scala-js" }
 ]


### PR DESCRIPTION
We will get it from `series/2.x`.