### PR TITLE
Thin CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.16, 3.1.2, 2.13.8]
-        java: [temurin@8, temurin@11, temurin@17]
+        java: [temurin@8, temurin@17]
         project: [rootJS, rootJVM, rootNative]
         exclude:
           - scala: 2.12.16
-            java: temurin@11
-          - scala: 2.12.16
             java: temurin@17
-          - scala: 3.1.2
-            java: temurin@11
           - scala: 3.1.2
             java: temurin@17
           - project: rootJS
-            java: temurin@11
-          - project: rootJS
             java: temurin@17
-          - project: rootNative
-            java: temurin@11
           - project: rootNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
@@ -70,22 +62,6 @@ jobs:
           distribution: jdkfile
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
-
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v1
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
-        with:
-          distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
@@ -187,22 +163,6 @@ jobs:
           distribution: jdkfile
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
-
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v1
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
-        with:
-          distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
@@ -365,22 +325,6 @@ jobs:
           distribution: jdkfile
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
-
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v1
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
-        with:
-          distribution: jdkfile
-          java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
 
       - name: Download Java (temurin@17)
         id: download-java-temurin-17

--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,9 @@ ThisBuild / developers := List(
 )
 
 val JDK8 = JavaSpec.temurin("8")
-val JDK11 = JavaSpec.temurin("11")
 val JDK17 = JavaSpec.temurin("17")
 
-ThisBuild / githubWorkflowJavaVersions := Seq(JDK8, JDK11, JDK17)
+ThisBuild / githubWorkflowJavaVersions := Seq(JDK8, JDK17)
 
 lazy val root = tlCrossRootProject.aggregate(core)
 


### PR DESCRIPTION
Twelve CI job runs is too much. Having JDK8 and JDK17 should be enough.