### PR TITLE
Add `contains` method to `Vault`

### DIFF
--- a/core/src/main/scala/org/typelevel/vault/Vault.scala
+++ b/core/src/main/scala/org/typelevel/vault/Vault.scala
@@ -46,6 +46,11 @@ final class Vault private (private val m: Map[Unique.Token, Locker]) {
   private[vault] def lookup[A](k: Key[A]): Option[A] = lookup(k: LookupKey[A])
 
   /**
+   * Checks if the value of a key is in this vault
+   */
+  def contains[A](k: LookupKey[A]): Boolean = m.contains(k.unique)
+
+  /**
    * Insert a value for a given key. Overwrites any previous value.
    */
   def insert[A](k: InsertKey[A], a: A): Vault = new Vault(m + (k.unique -> Locker(k, a)))

--- a/core/src/main/scala/org/typelevel/vault/Vault.scala
+++ b/core/src/main/scala/org/typelevel/vault/Vault.scala
@@ -46,9 +46,12 @@ final class Vault private (private val m: Map[Unique.Token, Locker]) {
   private[vault] def lookup[A](k: Key[A]): Option[A] = lookup(k: LookupKey[A])
 
   /**
-   * Checks if the value of a key is in this vault
+   * Checks if the value of a key is in this vault.
+   *
+   * @param k
+   *   the key to lookup can be any LookupKey, InsertKey, or DeleteKey
    */
-  def contains[A](k: LookupKey[A]): Boolean = m.contains(k.unique)
+  def contains(k: DeleteKey): Boolean = m.contains(k.unique)
 
   /**
    * Insert a value for a given key. Overwrites any previous value.

--- a/core/src/test/scala/org/typelevel/vault/VaultSuite.scala
+++ b/core/src/test/scala/org/typelevel/vault/VaultSuite.scala
@@ -110,4 +110,30 @@ class VaultSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
     }
   }
 
+  test("Vault contains should be true for inserted values") {
+    PropF.forAllF { (i: Int) =>
+      val emptyVault: Vault = Vault.empty
+      val test = Key.newKey[IO, Int].map(k => emptyVault.insert(k, i).contains(k))
+
+      assertIO(test, true)
+    }
+  }
+
+  test("Vault contains should be false for keys not inserted") {
+    PropF.forAllF { (i: Int) =>
+      val test = for {
+        key1 <- Key.newKey[IO, Int]
+        key2 <- Key.newKey[IO, Int]
+      } yield Vault.empty.insert(key1, i).contains(key2)
+
+      assertIO(test, false)
+    }
+  }
+
+  test("Vault contains should be false when empty") {
+    val emptyVault: Vault = Vault.empty
+    val test = Key.newKey[IO, Int].map(k => emptyVault.contains(k))
+
+    assertIO(test, false)
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,20 @@ basicLookup.unsafeRunSync()
 ```
 
 ```scala mdoc:silent
+val containsKey = for {
+  key <- Key.newKey[IO, Bar]
+} yield {
+  Vault.empty
+    .insert(key, Bar("", 1, 2L))
+    .contains(key)
+}
+```
+
+```scala mdoc
+containsKey.unsafeRunSync()
+```
+
+```scala mdoc:silent
 val lookupValuesOfDifferentTypes = for {
   key1 <- Key.newKey[IO, Bar]
   key2 <- Key.newKey[IO, String]


### PR DESCRIPTION
I think this could be useful when only information about the presence of a key in a vault is needed.

As minor motivation, there are a small handful of places in `http4s` where this is the case:
- priorKnowledge in H2Client [here](https://github.com/http4s/http4s/blob/v0.23.16/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala#L285) and [here](https://github.com/http4s/http4s/blob/v0.23.16/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Client.scala#L360)
- for [`sendMessageBody` in H2Stream](https://github.com/http4s/http4s/blob/34fbd95ce53f86d009df11622a8ec4037854533a/ember-core/shared/src/main/scala/org/http4s/ember/core/h2/H2Stream.scala#L75)
